### PR TITLE
Expose minimum heat setting via API

### DIFF
--- a/pyairstage/airstageAC.py
+++ b/pyairstage/airstageAC.py
@@ -226,6 +226,17 @@ class AirstageAC:
             raise AirstageACError(f"Invalid mode value: {mode}")
         await self._set_device_parameter(ACParameter.INDOOR_LED, mode)
 
+    def get_minimum_heat(self) -> BooleanDescriptors | None:
+        if self._is_capability_available(ACParameter.MINIMUM_HEAT):
+            value = self._get_cached_device_parameter(ACParameter.MINIMUM_HEAT)
+            return VALUE_TO_BOOLEAN[int(value)]
+        return None
+
+    async def set_minimum_heat(self, mode: BooleanProperty):
+        if not isinstance(mode, BooleanProperty):
+            raise AirstageACError(f"Invalid mode value: {mode}")
+        await self._set_device_parameter(ACParameter.MINIMUM_HEAT, mode)
+
     def get_hmn_detection(self) -> BooleanDescriptors | None:
         if self._is_capability_available(ACParameter.HMN_DETECTION):
             value = self._get_cached_device_parameter(ACParameter.HMN_DETECTION)

--- a/pyairstage/constants.py
+++ b/pyairstage/constants.py
@@ -136,8 +136,11 @@ class ACParameter(enum.Enum):
     REFRESH_READ_PROPERTIES = "get_prop"
     VERTICAL_SWING = "iu_af_swg_vrt"
     VERTICAL_DIRECTION = "iu_af_dir_vrt"
+    HORIZONTAL_SWING = 'iu_af_dir_hrz'
+    HORIZONTAL_DIRECTION = 'iu_af_swg_hrz'
 
     HMN_DETECTION = "iu_hmn_det"
+    HMN_DETECTION_AUTO_SAVE = 'iu_hmn_det_auto_save'
 
     OUTDOOR_LOW_NOISE = "ou_low_noise"
 
@@ -150,6 +153,11 @@ class ACParameter(enum.Enum):
     # # Unclear what this does, seems to somewhat correlate to af_vertical_direction but not entirely
     # VERTICAL_SWING_POSITION = "af_vertical_num_dir"
     DEVICE_NAME = "deviceName"
+    MODEL = 'iu_model'
+
+    ERROR_CODE = 'iu_err_code'
+    DEMAND = 'iu_demand'
+    SIGN_RESET = 'iu_fltr_sign_reset'
 
     def __str__(self):
         return self._value_

--- a/pyairstage/constants.py
+++ b/pyairstage/constants.py
@@ -143,6 +143,8 @@ class ACParameter(enum.Enum):
 
     INDOOR_LED = "iu_wifi_led"
 
+    MINIMUM_HEAT = "iu_min_heat"
+
     # # below are readonly properties
     # DISPLAY_TEMPERATURE = "display_temperature"
     # # Unclear what this does, seems to somewhat correlate to af_vertical_direction but not entirely


### PR DESCRIPTION
This exposes the minimum heat setting via a boolean property, allowing toggling of the frost protect mode.