### PR TITLE
Expose minimum heat setting via API

### DIFF
--- a/pyairstage/airstageAC.py
+++ b/pyairstage/airstageAC.py
@@ -226,6 +226,17 @@ class AirstageAC:
             raise AirstageACError(f"Invalid mode value: {mode}")
         await self._set_device_parameter(ACParameter.INDOOR_LED, mode)
 
+    def get_minimum_heat(self) -> BooleanDescriptors | None:
+        if self._is_capability_available(ACParameter.MINIMUM_HEAT):
+            value = self._get_cached_device_parameter(ACParameter.MINIMUM_HEAT)
+            return VALUE_TO_BOOLEAN[int(value)]
+        return None
+
+    async def set_minimum_heat(self, mode: BooleanProperty):
+        if not isinstance(mode, BooleanProperty):
+            raise AirstageACError(f"Invalid mode value: {mode}")
+        await self._set_device_parameter(ACParameter.MINIMUM_HEAT, mode)
+
     def get_hmn_detection(self) -> BooleanDescriptors | None:
         if self._is_capability_available(ACParameter.HMN_DETECTION):
             value = self._get_cached_device_parameter(ACParameter.HMN_DETECTION)

--- a/pyairstage/constants.py
+++ b/pyairstage/constants.py
@@ -143,6 +143,8 @@ class ACParameter(enum.Enum):
 
     INDOOR_LED = "iu_wifi_led"
 
+    MINIMUM_HEAT = "iu_min_heat"
+
     # # below are readonly properties
     # DISPLAY_TEMPERATURE = "display_temperature"
     # # Unclear what this does, seems to somewhat correlate to af_vertical_direction but not entirely


### PR DESCRIPTION
This exposes the minimum heat setting via a boolean property, allowing toggling of the frost protect mode.