### PR TITLE
fix: set temp correctly when F instead of C

### DIFF
--- a/pyairstage/airstageAC.py
+++ b/pyairstage/airstageAC.py
@@ -147,7 +147,8 @@ class AirstageAC:
                 f"Invalid targetTemperature: {target_temperature}. Value must be {self._min_temp} <= target <= {self._max_temp}"
             )
 
-        actual_target = int(target_temperature * 10)
+        rounded_temp = round(target_temperature * 2) / 2
+        actual_target = int(rounded_temp * 10)
         await self._set_device_parameter(ACParameter.TARGET_TEMPERATURE, actual_target)
 
     def get_vertical_direction(self) -> VerticalPositionDescriptors | None:


### PR DESCRIPTION
Fixes the issue described in https://github.com/danielkaldheim/ha_airstage/issues/20

I have not tested this as I have a raspberry pi install of pyairstage that I cannot override